### PR TITLE
Improve install script documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#6](https://github.com/numbata/danger-pr-comment/pull/6): Setup danger workflows as an example - [@numbata](https://github.com/numbata).
 - [#1](https://github.com/numbata/danger-pr-comment/pull/1): Add comprehensive test suite with RSpec, Rubocop, and CI - [@dblock](https://github.com/dblock).
+* [#4](https://github.com/numbata/danger-pr-comment/pull/4): Improve install script documentation - [@dblock](https://github.com/dblock).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ on:
 
 jobs:
   danger:
-    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@main
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
     secrets: inherit
 ```
 
@@ -68,7 +68,7 @@ permissions:
 
 jobs:
   comment:
-    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@main
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
     secrets: inherit
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ Reusable GitHub Actions workflows for running Danger and posting a PR comment fr
 ## Table of Contents
 
 - [Usage](#usage)
+  - [Prerequisites](#prerequisites)
   - [Quick Install](#quick-install)
   - [Manual Setup](#manual-setup)
-- [Requirements](#requirements)
-  - [Dangerfile report example](#dangerfile-report-example)
-- [Inputs](#inputs)
+- [Implementation Details](#implementation-details)
+  - [JSON Report Output](#json-report-output)
+    - [Shared Dangerfile](#shared-dangerfile)
+    - [Custom at_exit Hook](#custom-at_exit-hook)
+  - [Permissions](#permissions)
+  - [Inputs](#inputs)
+    - [danger-run.yml](#danger-runyml)
+    - [danger-comment.yml](#danger-commentyml)
 - [License](#license)
 
 ## Usage
@@ -80,6 +86,9 @@ jobs:
   danger:
     uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
     secrets: inherit
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true
 ```
 
 Create `.github/workflows/danger-comment.yml` in your repository:
@@ -108,7 +117,18 @@ Using danger-pr-comment solves the problem of needing special permissions to pos
 
 ### JSON Report Output
 
-Your Dangerfile must write a JSON report to `ENV['DANGER_REPORT_PATH']` (for example, via a custom `at_exit` hook or a shared Dangerfile).
+Your Dangerfile must write a JSON report to `ENV['DANGER_REPORT_PATH']`.
+
+#### Shared Dangerfile
+
+```ruby
+# Import danger-pr-comment for automatic danger report export to JSON
+danger.import_dangerfile(gem: 'danger-pr-comment')
+```
+
+See [Dangerfile](Dangerfile) for implementation details.
+
+#### Custom `at_exit` Hook
 
 ```ruby
 # Dangerfile

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ From your repository root:
 curl -fsSL https://raw.githubusercontent.com/numbata/danger-pr-comment/main/scripts/install-workflows.sh | bash
 ```
 
-Use `--force` to overwrite existing workflow files. To target a specific directory:
+Use `--force` to overwrite existing workflow files `.github/workflows/danger.yml` and `.github/workflows/danger-comment.yml`: 
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/numbata/danger-pr-comment/main/scripts/install-workflows.sh | bash -s -- --force
+```
+
+To target a specific directory:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/numbata/danger-pr-comment/main/scripts/install-workflows.sh | bash -s -- --root /path/to/repo

--- a/scripts/install-workflows.sh
+++ b/scripts/install-workflows.sh
@@ -69,7 +69,7 @@ on:
 
 jobs:
   danger:
-    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@main
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
     secrets: inherit
 EOF
 
@@ -87,6 +87,6 @@ permissions:
 
 jobs:
   comment:
-    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@main
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
     secrets: inherit
 EOF

--- a/scripts/install-workflows.sh
+++ b/scripts/install-workflows.sh
@@ -71,6 +71,9 @@ jobs:
   danger:
     uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
     secrets: inherit
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true
 EOF
 
 write_file "$workflows_dir/danger-comment.yml" <<'EOF'

--- a/spec/scripts/install_workflows_spec.rb
+++ b/spec/scripts/install_workflows_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Workflow installation script', type: :integration do
 
     it 'uses the reusable workflow' do
       content = File.read(danger_yml_path)
-      expect(content).to include('uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@main')
+      expect(content).to include('uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0')
     end
 
     it 'inherits secrets' do
@@ -94,7 +94,7 @@ RSpec.describe 'Workflow installation script', type: :integration do
 
     it 'uses the reusable workflow' do
       content = File.read(danger_comment_yml_path)
-      expect(content).to include('uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@main')
+      expect(content).to include('uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0')
     end
 
     it 'inherits secrets' do


### PR DESCRIPTION
## Summary

I've migrated a project to danger-pr-comment in https://github.com/dblock/ruby-enum/pull/52. 

This PR improves the README documentation with better organization, clearer installation instructions, and version pinning for stability.

### Documentation Improvements
- Add comprehensive Prerequisites section with example Gemfile and Dangerfile setup
- Reorganize Requirements section into Implementation Details for better clarity
- Move Dangerfile report examples into dedicated JSON Report Output subsection
- Improve Inputs section structure with clearer subsection headers for each workflow

### Installation Enhancements
- Clarify which workflow files (`.github/workflows/danger.yml` and `.github/workflows/danger-comment.yml`) are overwritten with `--force` flag
- Add explicit example command demonstrating how to use the `--force` option
- Update all workflow references from `@main` to `@v0.1.0` for version pinning
- Apply version updates to both README examples and install script

### Benefits
- Better onboarding experience for new users with prerequisites upfront
- More stable installations using versioned workflow references
- Clearer documentation structure and improved readability
- Explicit examples for common use cases

## Test plan
- [x] Review documentation changes for clarity and accuracy
- [x] Verify example commands are correct
- [x] Confirm workflow references point to valid v0.1.0 tag
- [x] Check that all sections flow logically

🤖 Generated with [Claude Code](https://claude.com/claude-code)